### PR TITLE
Add CI & instructions to build under ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: Publish
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  publish:
+    name: "Build and publish unassemblize binary"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install prerequisite packages
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            ccache \
+            clang \
+            clang-format \
+            cmake \
+            doxygen \
+            git \
+            graphviz
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Generate build configuration
+        run: |
+          mkdir build && cd build
+          cmake ..
+
+      - name: Fixup build configuration
+        run: |
+          sed -i 's/-fcolor-diagnostics//' build/_deps/lief-build/CMakeFiles/LIB_LIEF.dir/flags.make
+
+      - name: Compile
+        run: |
+          make -C build --jobs $(nproc)
+
+      - name: Upload build
+        uses: actions/upload-artifact@v3
+        with:
+          name: unassemblize
+          path: build/unassemblize
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: build/unassemblize

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,67 @@
+# Building
+
+## Ubuntu 20.04 or higher
+
+Install dependencies:
+```sh
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update && apt-get install -y \
+  ccache \
+  clang \
+  clang-format \
+  cmake \
+  doxygen \
+  git \
+  graphviz
+```
+
+Clone repository and navigate inside:
+```sh
+git clone https://github.com/OmniBlade/unassemblize.git
+cd unassemblize/
+```
+
+Generate build configuration
+```sh
+mkdir build && cd build
+cmake ..
+
+# workaround for "gcc: error: unrecognized command line option '-fcolor-diagnostics'"
+sed -i 's/-fcolor-diagnostics//' _deps/lief-build/CMakeFiles/LIB_LIEF.dir/flags.make
+```
+
+Compile:
+```sh
+make --jobs $(nproc)
+
+wait...
+
+[100%] Built target unassemblize
+```
+
+Run executable:
+```
+$ ./unassemblize
+
+unassemblize r6 ~201fc23
+    x86 Unassembly tool
+
+Usage:
+  unassemblize [OPTIONS] [INPUT]
+Options:
+  -o --output     Filename for single file output. Default is program.S
+  -f --format     Assembly output format.
+  -c --config     Configuration file describing how to dissassemble the input
+                  file and containing extra symbol info. Default: config.json
+  -s --start      Starting address of a single function to dissassemble in
+                  hexidecimal notation.
+  -e --end        Ending address of a single function to dissassemble in
+                  hexidecimal notation.
+  -v --verbose    Verbose output on current state of the program.
+  --section       Section to target for dissassembly, defaults to '.text'.
+  --listsections  Prints a list of sections in the exe then exits.
+  -d --dumpsyms   Dumps symbols stored in the executable to the config file.
+                  then exits.
+  -h --help       Displays this help.
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.16)
 
 # Use packagename_ROOT for FindPackage.
 if(POLICY CMP0074)


### PR DESCRIPTION
Managed to build this using ubuntu 20.04/22.04, the LIEF build needed a hack due to a bug where `-fcolor-diagnostics` is deemed a valid flag for gcc when it isnt.

I didn't actually manage to disassemble anything yet though!